### PR TITLE
Fix vincent mistakes

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,8 +43,8 @@ var ClientClusters = map[string]map[string]string{
 		"ClusterEndpoint": os.Getenv("SVC_1A_CLUSTER_ENDPOINT"),
 	},
 	os.Getenv("PROD_1A_IDENTIFIER"): map[string]string{
-		"CACert":          os.Getenv("SVC_1A_CA_CERT"),
-		"ClusterEndpoint": os.Getenv("SVC_1A_CLUSTER_ENDPOINT"),
+		"CACert":          os.Getenv("PROD_1A_CA_CERT"),
+		"ClusterEndpoint": os.Getenv("PROD_1A_CLUSTER_ENDPOINT"),
 	},
 	os.Getenv("PROD_1B_IDENTIFIER"): map[string]string{
 		"CACert":          os.Getenv("PROD_1B_CA_CERT"),

--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -8,13 +8,13 @@ contexts:
 - context:
     cluster: {{ .ClusterEndpoint }}
     namespace: {{ .Namespace }}
-    user: k8s-user
-  name: k8s-1.7-{{ .ClusterEndpoint }}
-current-context: k8s-1.7-{{ .ClusterEndpoint }}
+    user: {{ .ClientID }}-user
+  name: {{ .ClientID }}-dex
+current-context: {{ .ClientID }}
 kind: Config
 preferences: {}
 users:
-- name: k8s-user
+- name: {{ .ClientID }}-user
   user:
     auth-provider:
       config:


### PR DESCRIPTION
## Problems

- The prod-1a kubeconfig generated by dex refers to svc-1a cluster
- User array is overwritten when merging kube config files

## Solution

- Fix reading wrong env var
- Ensure users are uniquely named per cluster (also making the context names shorter)