### PR TITLE
Update filename for downloaded kubeconfig

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -54,7 +54,7 @@ func renderToken(w http.ResponseWriter, caCert, clientID, clusterEndpoint, redir
 
 func renderKubeConfig(w http.ResponseWriter, ClientID, caCert, clusterEndpoint, idToken, refreshToken string, namespace string) {
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", "kubeconfig"))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s_%s_%s\"", "kubeconfig", ClientID, namespace))
 	renderTemplate(w, kubeConfigTmpl, tokenTmplData{
 		CACert:          caCert,
 		ClientID:        ClientID,

--- a/templates.go
+++ b/templates.go
@@ -54,7 +54,7 @@ func renderToken(w http.ResponseWriter, caCert, clientID, clusterEndpoint, redir
 
 func renderKubeConfig(w http.ResponseWriter, ClientID, caCert, clusterEndpoint, idToken, refreshToken string, namespace string) {
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s_%s_%s\"", "kubeconfig", ClientID, namespace))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s-%s-%s\"", "kubeconfig", ClientID, namespace))
 	renderTemplate(w, kubeConfigTmpl, tokenTmplData{
 		CACert:          caCert,
 		ClientID:        ClientID,


### PR DESCRIPTION
## Problem
When debugging issues, and downloading multiple kubeconfig files, its difficult to tell which one was for which cluster, namespace, etc

## Solution
Add namespace suffix to the downloaded kubeconfig file.